### PR TITLE
Fixed invalid anchor tags in right sidebar

### DIFF
--- a/src/components/rightSidebar.js
+++ b/src/components/rightSidebar.js
@@ -88,7 +88,12 @@ const SidebarLayout = ({ location }) => (
             if ((item.node.fields.slug === location.pathname) || (config.gatsby.pathPrefix + item.node.fields.slug) === location.pathname) {
               if (item.node.tableOfContents.items) {
                 innerItems = item.node.tableOfContents.items.map((innerItem, index) => {
-                  const itemId = innerItem.title ? innerItem.title.replace(/\s+/g, '').toLowerCase() : '#';
+                  let itemId;
+                  if (innerItem.url) {
+                    itemId = innerItem.url[0] === "#" ? innerItem.url.split("#")[1] : innerItem.url;
+                  } else {
+                    itemId = innerItem.title ? innerItem.title.replace(/\s+/g, '').toLowerCase() : '#';
+                  }
                   return (
                     <ListItem
                       key={index}


### PR DESCRIPTION
# Fixed invalid anchor tags in right sidebar

![image](https://user-images.githubusercontent.com/8535863/72492355-e9d0e580-3842-11ea-87e0-b0ade3535d88.png)

Some `<a>` tags in the right sidebar have invalid `href` attribute which cause the page to scroll to the top on clicking the link.

This PR fixes the above mentioned issue.