### PR TITLE
correct typo

### DIFF
--- a/content/01-setup-ui/02-styles-amd-fonts.md
+++ b/content/01-setup-ui/02-styles-amd-fonts.md
@@ -159,7 +159,7 @@ export default class MyDocument extends Document {
 }
 ```
 
-We now have a `render` function like every other React component, but this time we took the liberty to wrap our page content `<Main />` and page scripts `<NativeScript />` with a HTML and body tag. This way, we can inject the global styles and fonts to the `head` of the page.
+We now have a `render` function like every other React component, but this time we took the liberty to wrap our page content `<Main />` and page scripts `<NextScript />` with a HTML and body tag. This way, we can inject the global styles and fonts to the `head` of the page.
 
 Set the font-family in the style we already have in `pages/index.js` to see some changes:
 


### PR DESCRIPTION
Correct typo on "Styles and Fonts" page: changed `<NativeScript />` to `<NextScript />`

![Screenshot from 2020-01-17 15-27-48](https://user-images.githubusercontent.com/22549360/72619844-744a3f80-393e-11ea-8f52-a6183f74f308.png)
