### PR TITLE
Add Scotch.IO link

### DIFF
--- a/content/index.mdx
+++ b/content/index.mdx
@@ -6,7 +6,7 @@ metaDescription: "Years back, when I started writing as a guest author for scotc
 
 Welcome!
 
-Years back, when I started writing as a guest author for scotch.io dev blog, I was moved strongly by what we believed in as teachers. We believed that docs do a great job of isolating concepts and going in-depth on how they work. We also believed that this was not enough for real-life situations.
+Years back, when I started writing as a guest author for [scotch.io](https://scotch.io) dev blog, I was moved strongly by what we believed in as teachers. We believed that docs do a great job of isolating concepts and going in-depth on how they work. We also believed that this was not enough for real-life situations.
 
 If you know how to handle a request using node and you also know how to make HTTP stateful with sessions and cookies, it does not mean you know how to write authentication logic. As Scotch teachers and writers, we strived to go one more level above docs and show how to merge two or more technologies to make something useful.
 


### PR DESCRIPTION
This PR adds a URL for `scotch.io` in case any learner is interested in checking it out.