### PR TITLE
Fix typo in page title

### DIFF
--- a/content/04-authentication.md
+++ b/content/04-authentication.md
@@ -1,6 +1,6 @@
 ---
-title: "4.0 Auhentication"
-metaTitle: "Auhentication"
+title: "4.0 Authentication"
+metaTitle: "Authentication"
 metaDescription: "Add authentication to your frontend app."
 ---
 


### PR DESCRIPTION
Small typo in the page title.

Great work on this workshop, it's super helpful!