### PR TITLE
Add other requirements

### DIFF
--- a/content/00-before-you-start/02-skills-requirements.md
+++ b/content/00-before-you-start/02-skills-requirements.md
@@ -35,3 +35,6 @@ To get the best out of this workshop, you need to have spent a few days on JavaS
  - Windows
  - Linux
 
+## Other Requirements
+- Node (v10+)
+- NPM/Yarn (whichever package manager you prefer)


### PR DESCRIPTION
Hey Chris,

I'm adding this suggestion because I noticed that if one tries to use `create-next-app --example with-apollo` command with a node version lower than 10, they'll get this error.

<img width="825" alt="Screenshot 2020-04-08 at 1 24 51 AM" src="https://user-images.githubusercontent.com/25608335/78731626-1ffc9d80-7938-11ea-8bd9-aef708766b42.png">

It's a common error and I figured some folks might not know why they get that error so I decided to add the node version to **Other Requirements**.
If there's a better place to add this or you feel it makes the tutorial verbose, feel free to let me know - I can close this PR.